### PR TITLE
ci(terraform): run on all PRs

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -1,9 +1,7 @@
 name: terraform-ci
 on:
   pull_request:
-    paths:
-      - 'terraform/**'
-      - '.github/workflows/terraform-ci.yml'
+    types: [opened, synchronize, reopened]
 
 jobs:
   tf:


### PR DESCRIPTION
Prevents 'Expected' required context from hanging.